### PR TITLE
fix: removed lookbehind marker on regex

### DIFF
--- a/assets/javascripts/lib/get-gov-addr-from-yml.js
+++ b/assets/javascripts/lib/get-gov-addr-from-yml.js
@@ -16,7 +16,7 @@ export async function getGovAddrFromYml(daoName) {
     } else if (part.match("abi:")) {
       tokens[curIdx].daoName = part
         .split("abi: ")[1]
-        ?.replace(/(?<=\w)(govern(or|ance)+)$/gi, "")
+        ?.replace(/(\w)(govern(or|ance)+)$/gi, "")
         .toLowerCase();
     }
   });


### PR DESCRIPTION
### Changelog

 - [X] Removed look behind from rgx that's not yet supported by safari and iOS