### PR TITLE
Fix banner crash on shielded (Shutter) votes; custom proposal link URLs

### DIFF
--- a/assets/javascripts/discourse/components/proposal-item.hbs
+++ b/assets/javascripts/discourse/components/proposal-item.hbs
@@ -31,7 +31,14 @@
       </div>
     </div>
     <div class="vote-breakdown">
-      {{vote-breakdown loading=this.loading breakdown=this.proposal.voteBreakdown proposalUrl=this.link}}
+      {{#if this.shielded}}
+        <div class="t-light">
+          {{d-icon "lock"}}
+          Shielded vote &mdash; results are revealed when voting ends
+        </div>
+      {{else}}
+        {{vote-breakdown loading=this.loading breakdown=this.proposal.voteBreakdown proposalUrl=this.link}}
+      {{/if}}
     </div>
   </div>
 </div>

--- a/assets/javascripts/discourse/components/proposal-item.js
+++ b/assets/javascripts/discourse/components/proposal-item.js
@@ -6,6 +6,7 @@ import {
   getResults,
   getVoteBreakdownByProposal,
 } from "../../lib/vote-breakdown";
+import voting from "../../lib/snapshot/index";
 
 export default Component.extend({
   proposal: {},
@@ -20,6 +21,14 @@ export default Component.extend({
 
   text: computed(function () {
     return this.getText(this.proposal);
+  }),
+
+  // Shutter-shielded proposals have encrypted vote choices until the
+  // vote closes, so there is no breakdown to display while active
+  shielded: computed(function () {
+    return (
+      this.proposal.privacy === "shutter" && this.proposal.state === "active"
+    );
   }),
 
   showRedirectButton: computed(function () {
@@ -58,20 +67,36 @@ export default Component.extend({
   },
 
   getLink() {
-    const nLink = getProposalLink(this.proposal, this.tokenContract);
+    const nLink = getProposalLink(
+      this.proposal,
+      this.tokenContract,
+      this.siteSettings
+    );
 
     set(this, "link", nLink);
   },
 
   async getBreakdown() {
-    if (this.proposal.type === "Off-chain") {
-      set(this, "loading", true);
+    if (this.proposal.type !== "Off-chain") {
+      return;
+    }
+    // Skip vote types we can't tally (e.g. copeland) and shielded votes,
+    // whose choices are encrypted until the proposal closes
+    if (this.shielded || !voting[this.proposal.proposalType]) {
+      return;
+    }
+    set(this, "loading", true);
+    try {
       const proposal = { ...this.proposal };
       const withScores = getVoteBreakdownByProposal(
         await getResults(proposal.space, proposal, proposal.votes)
       );
 
       set(this, "proposal", withScores);
+    } catch (error) {
+      // leave the proposal without a breakdown rather than
+      // wedging the banner on the loading spinner
+    } finally {
       set(this, "loading", false);
     }
   },

--- a/assets/javascripts/discourse/components/vote-breakdown.js
+++ b/assets/javascripts/discourse/components/vote-breakdown.js
@@ -14,6 +14,7 @@ export default Component.extend({
   sortVotes(votes) {
     if (
       Array.isArray(votes) &&
+      votes.length > 1 &&
       !(votes[0].name === "For" || votes[1].name === "Against")
     ) {
       return votes.sort((a, b) => (a.rawCount < b.rawCount ? 1 : -1));

--- a/assets/javascripts/discourse/components/vote-reason-form.js
+++ b/assets/javascripts/discourse/components/vote-reason-form.js
@@ -52,7 +52,7 @@ export default Component.extend({
 
   proposalLink: function () {
     const proposal = this.proposals[this.proposalId];
-    const link = getProposalLink(proposal);
+    const link = getProposalLink(proposal, "", this.siteSettings);
     return link ? `[${proposal.title}](${link})` : `### ${proposal.title}`;
   },
 

--- a/assets/javascripts/lib/get-proposal-link.js
+++ b/assets/javascripts/lib/get-proposal-link.js
@@ -1,16 +1,32 @@
 const { BigInt } = window;
 
-export default function getProposalLink(proposal, tokenContract) {
+function applyTemplate(template, id, space) {
+  return template.replace("{id}", id).replace("{space}", space ?? "");
+}
+
+export default function getProposalLink(proposal, tokenContract, siteSettings = {}) {
   if (!proposal) {
     return "";
   }
 
   let nLink;
   if (proposal.type === "Off-chain") {
-    nLink = `https://snapshot.org/#/${proposal.snapshotId}/proposal/${proposal.id}`;
+    nLink = siteSettings.Custom_offchain_proposal_url
+      ? applyTemplate(
+          siteSettings.Custom_offchain_proposal_url,
+          proposal.id,
+          proposal.snapshotId
+        )
+      : `https://snapshot.org/#/${proposal.snapshotId}/proposal/${proposal.id}`;
   } else {
     const proposalId = BigInt(proposal.id).toString();
-    nLink = tokenContract
+    nLink = siteSettings.Custom_onchain_proposal_url
+      ? applyTemplate(
+          siteSettings.Custom_onchain_proposal_url,
+          proposalId,
+          proposal.snapshotId
+        )
+      : tokenContract
       ? `https://tally.xyz/governance/eip155:1:${tokenContract}/proposal/${proposalId}`
       : "";
   }

--- a/assets/javascripts/lib/voting-history/gql/off-chain-fetcher.js
+++ b/assets/javascripts/lib/voting-history/gql/off-chain-fetcher.js
@@ -110,7 +110,7 @@ const parseProposals = (proposals = []) =>
     title: parseMdLink(proposal.title),
     shortname: proposal.title.slice(0, 40) + "...",
     voteCount: proposal.votes,
-    voteBreakdown: { For: 0, Abstain: 0, Against: 0, total: 0 },
+    voteBreakdown: {},
     endsAt: moment.unix(proposal.endsAt).format("MMM D, YYYY"),
     voteStarts: moment.unix(proposal.start).format("MMM D, YYYY"),
     dateDescription: dateDiff(proposal.endsAt),
@@ -120,6 +120,8 @@ const parseProposals = (proposals = []) =>
     network: proposal.network,
     snapshot: proposal.snapshot,
     proposalType: proposal.type,
+    privacy: proposal.privacy,
+    state: proposal.state,
   }));
 
 export async function fetchActiveOffChainProposals(daoNames, daysAgo) {

--- a/assets/javascripts/lib/voting-history/gql/queries.js
+++ b/assets/javascripts/lib/voting-history/gql/queries.js
@@ -64,6 +64,7 @@ export const proposal = {
         start
         snapshot
         type
+        privacy
         strategies {
           name
           network

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -33,5 +33,7 @@ en:
     Karma_API_Key: "API key to save data to the Karma api"
     See_on_Tally_button: "Show button to view proposal on Tally"
     See_on_Snapshot_button: "Show button to view proposal on Snapshot"
+    Custom_offchain_proposal_url: "Custom URL for off-chain proposal links. Use {id} for the proposal id and {space} for the snapshot space. Ex: https://vote.ensdao.org/#/offchain/{id}. Leave blank to link to snapshot.org"
+    Custom_onchain_proposal_url: "Custom URL for on-chain proposal links. Use {id} for the proposal id (decimal). Ex: https://vote.ensdao.org/#/onchain/{id}. Leave blank to link to tally.xyz"
     Show_on_chain_proposals: "Show on chain proposals on banner"
     Show_off_chain_proposals: "Show off chain proposals on banner"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -52,6 +52,12 @@ Proposal_Banner:
   See_on_Snapshot_button:
     default: true
     client: true
+  Custom_offchain_proposal_url:
+    default: ""
+    client: true
+  Custom_onchain_proposal_url:
+    default: ""
+    client: true
   Banner_description:
     default: "See the latest active proposals"
     client: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-stats",
-  "version": "1.4.1-beta1",
+  "version": "1.4.2",
   "repository": "https://github.com/show-karma/discourse-plugin",
   "author": "Karma",
   "license": "MIT",

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,7 +3,7 @@
 
 # name: karma-score
 # about: Show karma stats onto the user's profile
-# version: 1.4.1
+# version: 1.4.2
 # authors: Karma
 # url: https://github.com/show-karma/discourse-plugin
 


### PR DESCRIPTION
## Context

Reported by the ENS DAO forum (discuss.ens.domains): the Active Proposals banner breaks on shielded (Shutter) Snapshot votes — the proposal hangs on a loading spinner. They also asked for proposal links to point at their own vote site (vote.ensdao.org) instead of snapshot.org/tally.xyz.

## Root cause

ENS's shielded elections use Snapshot's `copeland` vote type, which has no entry in the plugin's scoring-class map (`lib/snapshot/index.js`). `new voting[proposal.proposalType](...)` therefore threw (`new undefined()`), and since `getBreakdown()` had no error handling, `loading` was never reset — the card spun forever. Additionally, shielded votes have encrypted choices while the proposal is active, so no meaningful tally exists until the vote closes.

## Changes

- **`proposal-item.js`**: skip the vote breakdown for unrecognized proposal types and for active shutter-shielded proposals; wrap `getBreakdown()` in try/catch/finally so no scoring failure can ever wedge the spinner again
- **`proposal-item.hbs`**: show a 🔒 "Shielded vote — results are revealed when voting ends" note for active shielded proposals
- **`queries.js` / `off-chain-fetcher.js`**: fetch and pass through `privacy` and `state`; empty default breakdown so skipped proposals don't render fake For/Against/Abstain rows
- **`vote-breakdown.js`**: guard `sortVotes` against empty/single-element arrays (latent crash)
- **`get-proposal-link.js`** + new site settings `Custom_offchain_proposal_url` / `Custom_onchain_proposal_url` with `{id}` / `{space}` placeholders. For ENS: `https://vote.ensdao.org/#/offchain/{id}` and `https://vote.ensdao.org/#/onchain/{id}` (on-chain `{id}` is the decimal form). Blank settings keep current snapshot.org / tally.xyz behavior.

## Backwards compatibility

No behavior change for existing forums: new settings default to empty (links unchanged — covered by tests), and supported vote types tally exactly as before. Only previously-crashing paths behave differently.

## Testing

- Node harness running the real lib code against the live Snapshot hub: confirmed the old code crashes on all 3 current ENS `copeland` proposals, the guard skips them, `basic` proposals still compute correct breakdowns, and link templates match the ENS example URLs character-for-character (including hex→decimal on-chain ID conversion)
- Full end-to-end in a local Discourse v3.5.2 dev instance (Docker) with `DAO_names=ens`, verified in headless Chromium: the live shielded election renders with the shielded note (no spinner hang), closed copeland proposal renders without a tally, regular breakdowns unchanged, and all "View proposal" buttons open the correct vote.ensdao.org URLs


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom proposal links for both off-chain and on-chain proposals.
  * Shielded votes now display a lock message until results are revealed.

* **Bug Fixes**
  * Improved vote breakdown handling so it no longer shows incomplete or unsupported results.
  * Fixed a sorting issue for vote lists with fewer than two entries.
  * Vote breakdown loading is now more resilient if data retrieval fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->