### PR TITLE
chore(links): migrate app links to karmahq.org, centralize legacy API host

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Karma discourse plugin can be used by DAOs on their forum to display forum user'
 
 __Step 1__: To install the plugin, you can follow the [Install Plugins in Discourse](https://meta.discourse.org/t/install-plugins-in-discourse/19157) official instructions.
 
-__Step 2__: After the installation, the user should go to the plugins page (Admin -> Plugins) and hit Settings under `Karma` plugin. Then, set the Dao Name as registered at [Karma](https://karmahq.xyz).
+__Step 2__: After the installation, the user should go to the plugins page (Admin -> Plugins) and hit Settings under `Karma` plugin. Then, set the Dao Name as registered at [Karma](https://karmahq.org).
 ![plugin-page](./docs/assets/plugins.png)
 
 ---

--- a/app/controllers/karma_controller.rb
+++ b/app/controllers/karma_controller.rb
@@ -7,14 +7,13 @@ class KarmaScore::KarmaController < ::ApplicationController
 
   before_action :ensure_logged_in
 
-  # api_url = "https://api.karmahq.xyz/api/discourse"
   attr_accessor :api_url, :api_token, :delegate_thread_id, :dao_names, :headers
 
   def initialize()
     @dao_names = SiteSetting.DAO_names
     @api_token = SiteSetting.Karma_API_Key
     @delegate_thread_id = SiteSetting.Delegate_pitch_thread_id
-    @api_url = "https://api.karmahq.xyz/api/forum-user"
+    @api_url = "#{KarmaScore::API_URL}/forum-user"
     # @api_url = "http://192.168.123.101:3001/api/forum-user"
     @headers = { "Content-Type" => "application/json", "authorization" => api_token }
   end

--- a/assets/javascripts/discourse/components/karma-stats.hbs
+++ b/assets/javascripts/discourse/components/karma-stats.hbs
@@ -7,7 +7,7 @@
         {{#if this.siteSettings.Show_Karma_logo}}
           <a
             alt="Show Karma App"
-            href="https://karmahq.xyz"
+            href={{this.karmaAppUrl}}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/assets/javascripts/discourse/components/karma-stats.js
+++ b/assets/javascripts/discourse/components/karma-stats.js
@@ -3,9 +3,12 @@ import { inject as service } from "@ember/service";
 import { action, computed, set } from "@ember/object";
 import { htmlSafe } from "@ember/template";
 import KarmaStats from "../../lib/stats/index";
+import { karmaAppUrl } from "../../lib/consts";
 
 export default Component.extend({
   router: service(),
+
+  karmaAppUrl,
 
   profile: {},
 
@@ -20,7 +23,7 @@ export default Component.extend({
   availableDaos: [],
 
   karmaDelegatorsUrl: computed(function () {
-    return `https://karmahq.xyz/dao/${this.daoName?.toLowerCase()}/delegators/${this.profile.username}`;
+    return `${karmaAppUrl}/dao/${this.daoName?.toLowerCase()}/delegators/${this.profile.username}`;
   }),
 
   userNotFoundMessage: computed(function () {

--- a/assets/javascripts/discourse/components/profile-summary-votes.hbs
+++ b/assets/javascripts/discourse/components/profile-summary-votes.hbs
@@ -4,7 +4,7 @@
       {{#if this.siteSettings.Show_Karma_logo}}
         <a
           alt="Show Karma App"
-          href={{concat "https://karmahq.xyz/profile/" this.profile.address}}
+          href={{concat this.karmaAppUrl "/profile/" this.profile.address}}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/assets/javascripts/discourse/components/profile-summary-votes.js
+++ b/assets/javascripts/discourse/components/profile-summary-votes.js
@@ -3,9 +3,12 @@ import { inject as service } from "@ember/service";
 import { computed, set } from "@ember/object";
 import VotingHistory from "../../lib/voting-history/index";
 import KarmaApiClient from "../../lib/karma-api-client";
+import { karmaAppUrl } from "../../lib/consts";
 
 export default Component.extend({
   router: service(),
+
+  karmaAppUrl,
 
   profile: {},
 

--- a/assets/javascripts/lib/consts.js
+++ b/assets/javascripts/lib/consts.js
@@ -1,3 +1,4 @@
+export const karmaAppUrl = "https://karmahq.org";
 export const karmaApiUrl = "https://api.karmahq.xyz/api";
 // export const karmaApiUrl = "http://192.168.123.101:3001/api";
 // export const stageApiUrl = "http://192.168.123.101:3001/api";

--- a/assets/javascripts/lib/stats/index.js
+++ b/assets/javascripts/lib/stats/index.js
@@ -1,7 +1,7 @@
 import { set } from "@ember/object";
 import { shortenNumber } from "../shorten-number";
 import { htmlSafe } from "@ember/template";
-import { karmaApiUrl } from "../consts";
+import { karmaApiUrl, karmaAppUrl } from "../consts";
 import { Mixpanel } from "../mixpanel";
 /**
  * Karma stats fetcher
@@ -42,7 +42,7 @@ const KarmaStats = {
       if (delegates) {
         const { stats } = delegates;
         userStats.delegatedVotes = `
-        <a href="https://karmahq.xyz/dao/${daoName.toLowerCase()}/delegators/${data.ensName || data.address
+        <a href="${karmaAppUrl}/dao/${daoName.toLowerCase()}/delegators/${data.ensName || data.address
           }" target="_blank">${shortenNumber(delegates.delegatedVotes || 0)}</a>`;
 
         userStats.snapshotVotingStats =
@@ -117,7 +117,7 @@ const KarmaStats = {
         <a
           target="_blank"
           rel="noopener noreferrer"
-          href="https://www.karmahq.xyz/dao/link/forum?dao=${daoName?.toLowerCase()}"
+          href="${karmaAppUrl}/dao/link/forum?dao=${daoName?.toLowerCase()}"
         >
             Link Wallet
         </a>`

--- a/assets/javascripts/lib/voting-history/gql/on-chain-fetcher.js
+++ b/assets/javascripts/lib/voting-history/gql/on-chain-fetcher.js
@@ -4,10 +4,9 @@ import { history, proposal as proposalQuery } from "./queries";
 import { parseMdLink } from "../../parse-md-link";
 import { dateDiff } from "../../date-diff";
 import { getVoteBreakdown } from "../../vote-breakdown";
+import { karmaApiUrl } from "../../consts";
 
-const subgraphUrl = new URL(
-  "https://api.karmahq.xyz/api/dao/discourse/plugin"
-);
+const subgraphUrl = new URL(`${karmaApiUrl}/dao/discourse/plugin`);
 
 /**
  * Concat proposal and votes into a common interface

--- a/assets/javascripts/lib/voting-history/index.js
+++ b/assets/javascripts/lib/voting-history/index.js
@@ -3,8 +3,9 @@ import { fetchOffChainProposalVotes } from "./gql/off-chain-fetcher";
 import { fetchOnChainProposalVotes } from "./gql/on-chain-fetcher";
 import { moonriverFetcher } from "./moonbeam/moonbeam";
 import template from "./template";
+import { karmaAppUrl } from "../consts";
 
-const karma = "https://karmahq.xyz/profile";
+const karma = `${karmaAppUrl}/profile`;
 
 const VotingHistory = {
   shouldShowVotingHistory(ctx) {

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,6 +17,7 @@ register_asset "stylesheets/vote-reason-form.scss"
 after_initialize do
   module ::KarmaScore
     PLUGIN_NAME ||= "KarmaScore"
+    API_URL ||= "https://api.karmahq.xyz/api"
 
     class Engine < ::Rails::Engine
       engine_name PLUGIN_NAME


### PR DESCRIPTION
Part of DEV-617 (karmahq.xyz → karmahq.org).

This plugin renders Karma links directly into DAO forum pages, so it is one of
the more visible surfaces of the move. Two independent commits:

## 1. App links → `karmahq.org` (phase 2)

Every URL the plugin renders into a forum — delegate profile, delegators list,
the wallet-link CTA in the error message, and the two Karma logo links — now
points at `karmahq.org`.

The host was inlined in six places across JS and Handlebars. It now sits next to
the existing `karmaApiUrl` in `assets/javascripts/lib/consts.js` as
`karmaAppUrl`; the two Ember templates read it through a component property
rather than hardcoding it, since templates cannot import.

Note one incidental normalisation: `lib/stats/index.js` built the wallet-link
CTA against `www.karmahq.xyz` while every other link in the plugin used the
apex. They now all use the apex `karmahq.org`. Both hosts are in scope for this
phase and `www` redirects to the apex, so this is cosmetic — calling it out so
it does not look like an accidental drop.

Posts already rendered in forum databases still carry `.xyz` URLs. Those keep
working: `karmahq.xyz` is not being sunset, it stays live as a redirect
permanently.

## 2. Legacy API host centralised, value unchanged (phase 3)

`api.karmahq.xyz` **stays on `.xyz`** in this PR. It cannot move until the MCP
OAuth audience migration lands — the `aud` claim is verified by exact equality
and the signing secret is shared with the out-of-tree `karma-oauth` service, so
flipping the host invalidates every live token.

What did change is that the host was inlined in two places that bypassed the
existing constant:

- `lib/voting-history/gql/on-chain-fetcher.js` built `subgraphUrl` from a
  literal → now derives it from `karmaApiUrl`.
- `app/controllers/karma_controller.rb` had the literal in `initialize` → now
  reads a new `KarmaScore::API_URL` constant in `plugin.rb`, alongside
  `PLUGIN_NAME`.

Both runtimes (browser JS and Rails) now have exactly one place to edit, so the
phase-3 flip is a one-line change per runtime instead of a grep.

Also removed a commented-out `api_url` line naming an `/api/discourse` path the
controller never called — it was stale and would have shown up as a false
positive in future domain greps.

## Deliberately left on `.xyz`

| Reference | Where | Phase gate |
|---|---|---|
| `api.karmahq.xyz` | `plugin.rb`, `lib/consts.js` | **Phase 3.** Blocked on the MCP OAuth audience migration. |
| `stageapi.karmahq.xyz` | `lib/consts.js` (commented-out dev override) | **Phase 3.** Same gate; left in place so it stays paired with the line above. |
| `info@karmahq.xyz` | `README.md` install instructions | **Phase 5.** No SPF/DKIM on `karmahq.org` yet. |

## Verification

Re-grepped for `karmahq\.(xyz|org)` — 6 remaining occurrences, every one listed
above.

Syntax-checked each touched JS module with `node --check`; all pass except
`karma-stats.js`, which fails only on its pre-existing `@action` decorators
(unsupported by bare Node, unrelated to this diff). The repo has no JS test or
lint script and no Ruby toolchain available here, so the Ember/Rails wiring was
verified by reading rather than executing.

Worth a reviewer's eye on the two template changes
(`karma-stats.hbs`, `profile-summary-votes.hbs`) — they now resolve the host
from a component property, and a typo there degrades to a link with no href
rather than a hard failure.

## Merge

The phase-2 half must not land before `karmahq.org` serves the app, otherwise
every forum page starts rendering links to a host that does not answer.

**Do not merge until `karmahq.org` is live and serving `/profile/:address` and
`/dao/:dao/delegators/:handle`.** The phase-3 commit is inert and could be
cherry-picked ahead of that gate if it is useful on its own.
